### PR TITLE
added FocusID method

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -38,6 +38,9 @@ const MR_DBUS_IFACE = `
         <method name="FocusPID">
             <arg type="s" direction="out" />
         </method>
+        <method name="FocusID">
+            <arg type="s" direction="out" />
+        </method>
         <method name="FocusClass">
             <arg type="s" direction="out" />
         </method>
@@ -65,9 +68,9 @@ class Extension {
         let win = global.get_window_actors()
             .map(a => a.meta_window)
             .map(w => ({ focus: w.has_focus(), title: w.get_title() }));
-        for (let [_ignore , aWindow] of win.entries()) {
-            let [focus,theTitle] = Object.entries(aWindow);
-            if (focus[1] == true )
+        for (let [_ignore, aWindow] of win.entries()) {
+            let [focus, theTitle] = Object.entries(aWindow);
+            if (focus[1] == true)
                 return theTitle[1];
         }
         return "";
@@ -76,24 +79,35 @@ class Extension {
         let win = global.get_window_actors()
             .map(a => a.meta_window)
             .map(w => ({ focus: w.has_focus(), pid: w.get_pid() }));
-            for (let [_ignore , aWindow] of win.entries()) {
-                let [focus,thePID] = Object.entries(aWindow);
-                if (focus[1] == true )
-                    return ""+thePID[1]; // Turn number into string
-            }
-            return "";
+        for (let [_ignore, aWindow] of win.entries()) {
+            let [focus, thePID] = Object.entries(aWindow);
+            if (focus[1] == true)
+                return "" + thePID[1]; // Turn number into string
         }
+        return "";
+    }
+    FocusID() {
+        let win = global.get_window_actors()
+            .map(a => a.meta_window)
+            .map(w => ({ focus: w.has_focus(), id: w.get_id() }));
+        for (let [_ignore, aWindow] of win.entries()) {
+            let [focus, theID] = Object.entries(aWindow);
+            if (focus[1] == true)
+                return "" + theID[1]; // Turn number into string
+        }
+        return "";
+    }
     FocusClass() {
         let win = global.get_window_actors()
             .map(a => a.meta_window)
             .map(w => ({ focus: w.has_focus(), class: w.get_wm_class() }));
-            for (let [_ignore , aWindow] of win.entries()) {
-                let [focus,theClass] = Object.entries(aWindow);
-                if (focus[1] == true )
-                    return theClass[1];
-            }
-            return "";
+        for (let [_ignore, aWindow] of win.entries()) {
+            let [focus, theClass] = Object.entries(aWindow);
+            if (focus[1] == true)
+                return theClass[1];
         }
+        return "";
+    }
 }
 
 function init() {


### PR DESCRIPTION
Hi, 
I needed the ID (not the PID) of a window for scripting purpose.
I added the method to your extension.

Can't you merge your extension with [window-calls](https://extensions.gnome.org/extension/4724/window-calls/) ?


I'm using window-calls to make a fullscreen script, to go full screen on a 2 monitor setup.

```sh

wid=$(gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell/Extensions/WindowsExt --method org.gnome.Shell.Extensions.WindowsExt.FocusID | sed -E "s/\\('(.*)',\\)/\\1/g")
#Now move the window to any desired position as follows (example):
x=0
y=32  # panel height
width=3840
height=1048
gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell/Extensions/Windows --method org.gnome.Shell.Extensions.Windows.MoveResize ${wid} ${x} ${y} ${width} ${height}
```

this is the working script
I'm using my patched version with FocusID method.

Thanks for your work,






