### PR TITLE
Added GNOME 46 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
   "description": "Add new dbus call for windows to get windows list and some of theirs properties, plus details on window under focus.",
   "uuid": "window-calls-extended@hseliger.eu",
   "shell-version": [
-    "45"
+    "45",
+    "46"
   ],
   "version": 6,
   "url": "https://github.com/hseliger/window-calls-extended"


### PR DESCRIPTION
Extension works perfectly fine as is, yet requires metadata to explicitly state GNOME 46 support. Hence this PR