### PR TITLE
Support GNOME 47, version bump

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,8 +3,10 @@
   "description": "Add new dbus call for windows to get windows list and some of theirs properties, plus details on window under focus.",
   "uuid": "window-calls-extended@hseliger.eu",
   "shell-version": [
-    "45"
+    "45",
+    "46",
+    "47"
   ],
-  "version": 6,
+  "version": 7,
   "url": "https://github.com/hseliger/window-calls-extended"
 }


### PR DESCRIPTION
@hseliger 

Extension works on GNOME 46 and GNOME 47 by adding to the list of supported shell versions. 

Added version bump to go along with the GNOME 46/47 support. 

Tested on Fedora Rawhide in GNOME 47 beta. 
