### PR TITLE
Update for GNOME 48, version bump

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,8 +5,9 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
-  "version": 7,
+  "version": 8,
   "url": "https://github.com/hseliger/window-calls-extended"
 }


### PR DESCRIPTION
@hseliger 

No problem observed in GNOME 48 on Fedora Rawhide, after manually adding "48" to shell versions list. 

Fedora 42 with GNOME 48 should be available as a beta release shortly. Time to update the extension again. 
