### PR TITLE
Add Activate method to focus windows by ID

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,11 +26,18 @@ To get the title of the window with focus:
 gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell/Extensions/WindowsExt --method org.gnome.Shell.Extensions.WindowsExt.FocusTitle
 ```
 
+To activate/focus a window by its ID:
+```sh
+gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell/Extensions/WindowsExt --method org.gnome.Shell.Extensions.WindowsExt.Activate "WINDOW_ID"
+```
+
 Available methods are:
 * org.gnome.Shell.Extensions.WindowsExt.List
 * org.gnome.Shell.Extensions.WindowsExt.FocusTitle
 * org.gnome.Shell.Extensions.WindowsExt.FocusPID
+* org.gnome.Shell.Extensions.WindowsExt.FocusID
 * org.gnome.Shell.Extensions.WindowsExt.FocusClass
+* org.gnome.Shell.Extensions.WindowsExt.Activate
 
 ## Using from C++
 If using from C++, it requires the dbus-1 library. Parameters for the call to `dbus_message_new_method_call` would be

--- a/extension.js
+++ b/extension.js
@@ -47,6 +47,10 @@ const MR_DBUS_IFACE = `
         <method name="FocusClass">
             <arg type="s" direction="out" />
         </method>
+        <method name="Activate">
+            <arg type="s" direction="in" name="window_id"/>
+            <arg type="b" direction="out"/>
+        </method>
     </interface>
 </node>`;
 
@@ -110,5 +114,17 @@ export default class WCExtension {
                 return theClass[1];
         }
         return "";
+    }
+    Activate(windowId) {
+        let targetId = parseInt(windowId);
+        let win = global.get_window_actors()
+            .map(a => a.meta_window)
+            .find(w => w.get_id() === targetId);
+        
+        if (win) {
+            win.activate(global.get_current_time());
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
This commit adds a new D-Bus method 'Activate' that allows focusing/activating a window by its ID. This is useful for programmatic window management in Wayland environments where traditional tools like wmctrl have limitations.

Usage:
gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell/Extensions/WindowsExt --method org.gnome.Shell.Extensions.WindowsExt.Activate "WINDOW_ID"

The method returns a boolean indicating success/failure.