### PR TITLE
 Update for GNOME 49, version bump

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -64,7 +64,7 @@ export default class WCExtension {
     List() {
         let win = global.get_window_actors()
             .map(a => a.meta_window)
-            .map(w => ({ class: w.get_wm_class(), pid: w.get_pid(), id: w.get_id(), maximized: w.get_maximized(), focus: w.has_focus(), title: w.get_title() }));
+            .map(w => ({ class: w.get_wm_class(), pid: w.get_pid(), id: w.get_id(), maximized: w.is_maximized(), focus: w.has_focus(), title: w.get_title() }));
         return JSON.stringify(win);
     }
     FocusTitle() {

--- a/metadata.json
+++ b/metadata.json
@@ -6,8 +6,9 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
-  "version": 8,
+  "version": 9,
   "url": "https://github.com/hseliger/window-calls-extended"
 }


### PR DESCRIPTION
Tested and fully working on: 

```
gnome-shell --version
GNOME Shell 49.0
```